### PR TITLE
Use built-in $(CURDIR) instead of $(shell pwd).

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -4,7 +4,7 @@
 # that.  I prefer unresolved version and since simple $(shell pwd) looks
 # nicer than other two I'm sticking with bash :).
 SHELL := /bin/bash
-RUNDIR := $(shell pwd)
+RUNDIR := $(CURDIR)
 ifndef TOP
 TOP := $(shell rd=$(RUNDIR); top=$$rd; \
                until [ -r $$top/Rules.top ]; do \

--- a/mk/header.mk
+++ b/mk/header.mk
@@ -1,5 +1,5 @@
 ifndef d
-d := $(or $(TOP),$(shell pwd))
+d := $(or $(TOP),$(CURDIR))
 dir_stack :=
 # Automatic inclusion of the skel.mk at the top level - that way
 # Rules.top has exactly the same structure as other Rules.mk


### PR DESCRIPTION
Don't know if this will work on cygwin, so didn't update the documentation above the RUNDIR assignment line in mk/Makefile.

A comparison on Linux (Debian) with bash:

Makefile:

``` make
SHELL := /bin/bash

$(info CURDIR            $(CURDIR))
$(info PWD               $(PWD))
$(info shell echo `pwd`  $(shell echo `pwd`))
$(info shell pwd         $(shell pwd))
$(error testing)
```

Output:

```
$ make -krj5 -C subdir all
CURDIR            /home/t/src/ideas/non-rec/subdir
PWD               /home/t/src/ideas/linkedrec
shell echo `pwd`  /home/t/src/ideas/non-rec/subdir
shell pwd         /home/t/src/ideas/non-rec/subdir
make: Entering directory `/home/t/src/ideas/non-rec/subdir'
../mk/Makefile:7: *** testing.  Stop.
make: Leaving directory `/home/t/src/ideas/non-rec/subdir'
```
