### PR TITLE
Produce an error if SRCS contains an invalid path.

### DIFF
--- a/mk/footer.mk
+++ b/mk/footer.mk
@@ -7,7 +7,7 @@ else # Populate OBJS_ from SRCS
 
 # Expand wildcards in SRCS if they are given
 ifneq ($(or $(findstring *,$(SRCS)),$(findstring ?,$(SRCS)),$(findstring ],$(SRCS))),)
-  SRCS := $(notdir $(foreach sd,. $(SRCS_VPATH),$(wildcard $(addprefix $(d)/$(sd)/,$(SRCS)))))
+  SRCS := $(notdir $(foreach src,$(SRCS),$(or $(call find_in_vpath,$(src)),$(error $(src) does not exist! Check SRCS in $(d)/Rules.mk))))
   SRCS := $(filter-out $(SRCS_EXCLUDES), $(SRCS))
 endif
 

--- a/mk/skel.mk
+++ b/mk/skel.mk
@@ -250,5 +250,11 @@ dist_clean :
 	rm -rf $(TOP_BUILD_DIR)
 endif
 
+# Find all files that match a path or wildcard pattern anywhere in the
+# SRCS_VPATH
+define find_in_vpath
+$(strip $(foreach sd,. $(SRCS_VPATH),$(wildcard $(addprefix $(d)/$(sd)/,$(1)))))
+endef
+
 # Suck in the default rules
 include $(MK)/def_rules.mk


### PR DESCRIPTION
Hi Andrzej,

Previously, all wrong entries in `SRCS` would be silently filtered out. This change aims to keep Rules.mk files accurate, and easier to debug.

Thanks!
