### PR TITLE
Small bug on archive remakes due to changed sub archives only.

### DIFF
--- a/mk/skel.mk
+++ b/mk/skel.mk
@@ -198,16 +198,18 @@ SRCS_VPATH := src
 # in a larger archive.
 EXTRACT_DIR = $@_extract
 MAKECMD.a = $(call echo_cmd,AR $@) \
-	$(AR) $(ARFLAGS) $@ $(DEP_OBJS?) \
+	$(if $(DEP_OBJS?), \
+		$(AR) $(ARFLAGS) $@ $(DEP_OBJS?) \
+		&&) \
 	$(if $(DEP_ARCH?), \
-		&& mkdir -p $(EXTRACT_DIR) \
+		mkdir -p $(EXTRACT_DIR) \
 		&& cd $(EXTRACT_DIR) \
 		$(foreach lib,$(DEP_ARCH?),&& $(AR) xo $(lib)) \
 		&& cd - \
 		&& $(AR) $(ARFLAGS) $@ $(EXTRACT_DIR)/*.o \
 		&& rm -rf $(EXTRACT_DIR) \
-	) \
-	&& $(RANLIB) $@
+		&&) \
+	$(RANLIB) $@
 
 MAKECMD.$(SOEXT) = $(LINK.cc) $(DEP_OBJS) $(DEP_ARCH) $(DEP_LIBS) $(LIBS_$(@)) $(LDLIBS) -shared -o $@
 DEFAULT_MAKECMD = $(LINK.cc) $(DEP_OBJS) $(DEP_ARCH) $(DEP_LIBS) $(LIBS_$(@)) $(LDLIBS) -o $@


### PR DESCRIPTION
The bug is exemplified by the following scenario:

We have a target archive X.a that depends (not exclusively) on an archive Y.a. Y.a depends on an object Z.o. We then edit Z.c and call make (triggering a remake of Y.a). When X.a gets remade, $(DEP_OBJS?) is empty and the "ar" command barfs.